### PR TITLE
Letting people know how to embed this to Meteor

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,55 @@ The output generated:
   margin-right: 5px; }
 
 ```
+# Installatin On Meteor 1.3 + (NPM)
+
+> Note : remove any bootstrap (npm or atmo) package before adding it.
+
+## Steps
+    - Open up your operating system console and in the root of your project:
+    - DO `meteor remove standard-minifier-css` 
+    - Do `meteor add juliancwirko:postcss`
+    - DO `meteor add fourseven:scss`
+    - DO `npm install autoprefixer --save-dev`
+    - DO `meteor npm install --save https://github.com/jbokkers/bootstrap-bidirectional`
+            OR `npm install --save https://github.com/jbokkers/bootstrap-bidirectional`
+    - DO `meteor npm install` OR `npm install`
+    - DO `meteor npm update` OR `npm update`
+    - DO `meteor update`
+    - DO  open `_variables.scss` in `/node_modules/bootstrap-bidirectional/assets/stylesheets/bootstrap/_variables.scss`
+            and change the value of '$text-direction' to 'bidi'.
+    - DO   Create if not already  a `main.scss` in your project's `/client` directory, and input the following codes in it:
+    ...
+        @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/bootstrap/mixins/_bidirectional.scss';
+        @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/bootstrap/_variables.scss';
+        @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/_bootstrap-compass.scss';
+        @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/_bootstrap-mincer.scss';
+        @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/_bootstrap-sprockets.scss';
+        @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/_bootstrap.scss';
+    ...
+    - DO Create if not already a `main.js` in your project's `/client` directory, and append the following code in it:
+    ...
+        import 'bootstrap-bidirectional';
+    ...
+    Voila!
+    Now by triggering a jquery (meteor has build in jquery) function in some place you desire, you can change the dir value of the `html` tag.
+    Something like below:
+    - In your `spacebars` template:
+    ...
+        <template name="changeHTMLdir">
+            <button class="js-change-dir-rlt">RTL</button>
+            <button class="js-change-dir-ltr">LTR</button>
+        </template>
+    ...
+    - In you template's events :
+    ...
+        Template.navbar.events({
+            "click .js-change-dir-rlt": function(){
+                $('html').attr('dir','rtl');
+            },
+            "click .js-change-dir-ltr": function(){
+                $('html').attr('dir','ltr');
+            },
+        });
+    ...
+    - Now code you bootstrap web App with bidirectional support in Meteor.

--- a/README.md
+++ b/README.md
@@ -119,20 +119,20 @@ The output generated:
     ```
     - DO Create if not already a `main.js` in your project's `/client` directory, and append the following code in it:
     ```
-        import 'bootstrap-bidirectional';
+        import 'bootstrap-bidirectional'; //seems not working or not needed . correct me
     ```
     Voila!
     Now by triggering a jquery (meteor has build in jquery) function in some place you desire, you can change the dir value of the `html` tag.
     Something like below:
     - In your `spacebars` template:
-    ```
+```
         <template name="changeHTMLdir">
             <button class="js-change-dir-rlt">RTL</button>
             <button class="js-change-dir-ltr">LTR</button>
         </template>
-    ```
+```
     - In you template's events :
-    ```
+```
         Template.navbar.events({
             "click .js-change-dir-rlt": function(){
                 $('html').attr('dir','rtl');
@@ -141,5 +141,5 @@ The output generated:
                 $('html').attr('dir','ltr');
             },
         });
-    ```
+```
     - Now code you bootstrap web App with bidirectional support in Meteor.

--- a/README.md
+++ b/README.md
@@ -109,30 +109,30 @@ The output generated:
     - DO  open `_variables.scss` in `/node_modules/bootstrap-bidirectional/assets/stylesheets/bootstrap/_variables.scss`
             and change the value of '$text-direction' to 'bidi'.
     - DO   Create if not already  a `main.scss` in your project's `/client` directory, and input the following codes in it:
-    ...
+    ```
         @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/bootstrap/mixins/_bidirectional.scss';
         @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/bootstrap/_variables.scss';
         @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/_bootstrap-compass.scss';
         @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/_bootstrap-mincer.scss';
         @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/_bootstrap-sprockets.scss';
         @import '{}/node_modules/bootstrap-bidirectional/assets/stylesheets/_bootstrap.scss';
-    ...
+    ```
     - DO Create if not already a `main.js` in your project's `/client` directory, and append the following code in it:
-    ...
+    ```
         import 'bootstrap-bidirectional';
-    ...
+    ```
     Voila!
     Now by triggering a jquery (meteor has build in jquery) function in some place you desire, you can change the dir value of the `html` tag.
     Something like below:
     - In your `spacebars` template:
-    ...
+    ```
         <template name="changeHTMLdir">
             <button class="js-change-dir-rlt">RTL</button>
             <button class="js-change-dir-ltr">LTR</button>
         </template>
-    ...
+    ```
     - In you template's events :
-    ...
+    ```
         Template.navbar.events({
             "click .js-change-dir-rlt": function(){
                 $('html').attr('dir','rtl');
@@ -141,5 +141,5 @@ The output generated:
                 $('html').attr('dir','ltr');
             },
         });
-    ...
+    ```
     - Now code you bootstrap web App with bidirectional support in Meteor.


### PR DESCRIPTION
I don't know much about sass/scss but I was looking for a way to embed bidirectional Bootstrap to Meteor, or any other framework which has a bidirectional functionality for RTL/LTR support.
I tried Foundation from Zurb, but for me, as I guess for most of ppl like me using Meteor, it's all a headache going through the learning curve of Foundation Zurb, and also learning how to embed it correctly in to meteor, since embedding it means to have call js onCreated and onDestroyed for each template instance to create certain components out of this framework to really work in meteor. $(document).foundation() simply wont work ever.
All these headaches for a single functionality of Bidirectional RTL/LTR Support was not true.
Ending up at your repo, I gave it a try, and found the way to use it in Meteor, I already have it in action with a project I'm working on now.
I'll do create a sample git repo if I could in future.
I did the things above, but since you know scss I was wondering if you could shorten the `main.scss` file content as described above, to something one-liner. Please keep in mind and I found this structure (having _bidirectional.scss on top) worked.
I'd be happy if you work on it.
Thanks for your great work on the project too.
Waiting for you next release on v4
