### PR TITLE
remove padding-horz for fixed-top

### DIFF
--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -139,9 +139,10 @@
 .navbar-fixed-top,
 .navbar-fixed-bottom {
   position: fixed;
-  // right: 0;
-  // left: 0;
-  @include position-horz(0); //
+  // in this case, left:0 and right:0 are correct as it makes the navbar full width
+  // so no need to use the padding-horz(0) mixin
+  right: 0;
+  left: 0;
   z-index: $zindex-navbar-fixed;
   // Undo the rounded corners
   @media (min-width: $grid-float-breakpoint) {

--- a/assets/stylesheets/bootstrap/mixins/_grid.scss
+++ b/assets/stylesheets/bootstrap/mixins/_grid.scss
@@ -4,10 +4,11 @@
 
 // Centered container element
 @mixin container-fixed($gutter: $grid-gutter-width) {
-    @include margin-pull(auto); // margin-right: auto;
-    @include margin-push(auto); // margin-left: auto;
-    @include padding-push((floor(($gutter / 2)))); // padding-left:  floor(($gutter / 2));
-    @include padding-pull((ceil(($gutter / 2)))); // padding-right: ceil(($gutter / 2));
+    //the mixins are not needed here because we expect this to be centered for all dir's
+    margin-right: auto; //@include margin-pull(auto); //
+    margin-left: auto; //@include margin-push(auto); //
+    padding-left:  floor(($gutter / 2)); // @include padding-push((floor(($gutter / 2)))); //
+    padding-right: ceil(($gutter / 2)); //@include padding-pull((ceil(($gutter / 2)))); //
     @include clearfix;
 }
 


### PR DESCRIPTION
I was trying to use this on a site that uses `.navbar-fixed-top`, and found that the correct `.left:0` and `.right:0` rules which made the nav full-width, were replaced with `padding-horz(0)` which resulted in the nav being fixed with and not centered.

Before this fix (we have _many_ other rtl issues)
![image](https://cloud.githubusercontent.com/assets/119129/19291470/91056168-8fd2-11e6-880f-89a3dc60d523.png)

After:
![image](https://cloud.githubusercontent.com/assets/119129/19291476/a00c92b2-8fd2-11e6-93f9-7da5c6ec4827.png)

Added a second commit that ensures `.container` is still centered when using `$text-direction:"bidi"`
